### PR TITLE
Patch `rte_ipsec_ses_from_crypto` to not rely on implicit cast.

### DIFF
--- a/patches/ipsec_group-cast-rte_ipsec_session.patch
+++ b/patches/ipsec_group-cast-rte_ipsec_session.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/librte_ipsec/rte_ipsec_group.h b/lib/librte_ipsec/rte_ipsec_group.h
+index 740fa7c99..1010c8d6e 100644
+--- a/lib/librte_ipsec/rte_ipsec_group.h
++++ b/lib/librte_ipsec/rte_ipsec_group.h
+@@ -50,10 +50,10 @@ rte_ipsec_ses_from_crypto(const struct rte_crypto_op *cop)
+ 
+ 	if (cop->sess_type == RTE_CRYPTO_OP_SECURITY_SESSION) {
+ 		ss = cop->sym[0].sec_session;
+-		return (void *)(uintptr_t)ss->opaque_data;
++		return (struct rte_ipsec_session *)(uintptr_t)ss->opaque_data;
+ 	} else if (cop->sess_type == RTE_CRYPTO_OP_WITH_SESSION) {
+ 		cs = cop->sym[0].session;
+-		return (void *)(uintptr_t)cs->opaque_data;
++		return (struct rte_ipsec_session *)(uintptr_t)cs->opaque_data;
+ 	}
+ 	return NULL;
+ }


### PR DESCRIPTION
The header `<rte_ipsec_group.h>` has a function `rte_ipsec_ses_from_crypto`
which relies on an implicit cast from a `void*` to `struct rte_ipsec_session*`,
which is illegal in C++. This makes the cast explicit so we can use the
header in nfapp.

Fixes NF-358.