### PR TITLE
Fix new compile error on statless/base:8.

### DIFF
--- a/patches/fix-igb-uio-compile.patch
+++ b/patches/fix-igb-uio-compile.patch
@@ -1,0 +1,21 @@
+Disable new warning when compiling igb_uio with newer gcc.
+
+From: Aaron Jones <aaron@vexing.codes>
+
+
+---
+ kernel/linux/igb_uio/Makefile |    1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/linux/igb_uio/Makefile b/kernel/linux/igb_uio/Makefile
+index f83bcc7c6..bbb559042 100644
+--- a/kernel/linux/igb_uio/Makefile
++++ b/kernel/linux/igb_uio/Makefile
+@@ -16,6 +16,7 @@ MODULE_CFLAGS += -I$(SRCDIR) --param max-inline-insns-single=100
+ MODULE_CFLAGS += -I$(RTE_OUTPUT)/include
+ MODULE_CFLAGS += -Winline -Wall -Werror
+ MODULE_CFLAGS += -include $(RTE_OUTPUT)/include/rte_config.h
++MODULE_CFLAGS += -Wno-implicit-fallthrough
+ 
+ #
+ # all source are stored in SRCS-y

--- a/patches/ipsec_group-cast-rte_ipsec_session.patch
+++ b/patches/ipsec_group-cast-rte_ipsec_session.patch
@@ -1,3 +1,12 @@
+Fix return types in rte_ipsec_ses_from_crypto.
+
+From: Travis Gockel <travis@gockelhut.com>
+
+
+---
+ lib/librte_ipsec/rte_ipsec_group.h |    4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
 diff --git a/lib/librte_ipsec/rte_ipsec_group.h b/lib/librte_ipsec/rte_ipsec_group.h
 index 740fa7c99..1010c8d6e 100644
 --- a/lib/librte_ipsec/rte_ipsec_group.h

--- a/patches/ring-free.patch
+++ b/patches/ring-free.patch
@@ -8,10 +8,10 @@ From: Aaron Jones <aaron@vexing.codes>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ring/rte_eth_ring.c b/drivers/net/ring/rte_eth_ring.c
-index aeb48f5ec..d5de3b5b7 100644
+index ab963a03c..17bfaaeb0 100644
 --- a/drivers/net/ring/rte_eth_ring.c
 +++ b/drivers/net/ring/rte_eth_ring.c
-@@ -660,7 +660,7 @@ rte_pmd_ring_remove(struct rte_vdev_device *dev)
+@@ -685,7 +685,7 @@ rte_pmd_ring_remove(struct rte_vdev_device *dev)
  		 * it is only necessary to delete the rings in rx_queues because
  		 * they are the same used in tx_queues
  		 */

--- a/patches/series
+++ b/patches/series
@@ -1,3 +1,4 @@
 # This series applies on GIT commit v19.05
 ring-free.patch
 ipsec_group-cast-rte_ipsec_session.patch
+fix-igb-uio-compile.patch


### PR DESCRIPTION
When moving to `stateless/base:8` a new build error occurred:

```
/tmp/dpdk/dpdk/build/build/kernel/linux/igb_uio/igb_uio.c: In function 'igbuio_pci_enable_interrupts':
/tmp/dpdk/dpdk/build/build/kernel/linux/igb_uio/igb_uio.c:230:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
   if (pci_alloc_irq_vectors(udev->pdev, 1, 1, PCI_IRQ_MSIX) == 1) {
      ^
/tmp/dpdk/dpdk/build/build/kernel/linux/igb_uio/igb_uio.c:240:2: note: here
  case RTE_INTR_MODE_MSI:
  ^~~~
/tmp/dpdk/dpdk/build/build/kernel/linux/igb_uio/igb_uio.c:250:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
   if (pci_alloc_irq_vectors(udev->pdev, 1, 1, PCI_IRQ_MSI) == 1) {
      ^
/tmp/dpdk/dpdk/build/build/kernel/linux/igb_uio/igb_uio.c:259:2: note: here
  case RTE_INTR_MODE_LEGACY:
  ^~~~
In file included from /tmp/dpdk/dpdk/build/build/kernel/linux/igb_uio/igb_uio.c:8:
./include/linux/device.h:1503:2: error: this statement may fall through [-Werror=implicit-fallthrough=]
  _dev_notice(dev, dev_fmt(fmt), ##__VA_ARGS__)
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/dpdk/dpdk/build/build/kernel/linux/igb_uio/igb_uio.c:267:3: note: in expansion of macro 'dev_notice'
   dev_notice(&udev->pdev->dev, "PCI INTX mask not supported\n");
   ^~~~~~~~~~
/tmp/dpdk/dpdk/build/build/kernel/linux/igb_uio/igb_uio.c:269:2: note: here
  case RTE_INTR_MODE_NONE:
  ^~~~
```

Made a new patch `fix-igb-uio-compile.patch` that adds `-Wno-implicit-fallthrough` to the `CFLAGS` of the compilation for that driver.

The ipsec patch didn't contain any commit message or author. I have added these to the patch (under Travis' name). I did this because I did `stg export -d ../patches/` to export my new patch, and suddenly stg was unable to import the ipsec patch without this information.

No idea why the line numbers changed in `ring-free.patch`, but they did. Tinfoil hat time?