### PR TITLE
v20.08-rc3

### DIFF
--- a/patches/ipsec_group-cast-rte_ipsec_session.patch
+++ b/patches/ipsec_group-cast-rte_ipsec_session.patch
@@ -8,10 +8,10 @@ From: Travis Gockel <travis@gockelhut.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/lib/librte_ipsec/rte_ipsec_group.h b/lib/librte_ipsec/rte_ipsec_group.h
-index 740fa7c99..1010c8d6e 100644
+index 47b33ca5e..27a2f6f26 100644
 --- a/lib/librte_ipsec/rte_ipsec_group.h
 +++ b/lib/librte_ipsec/rte_ipsec_group.h
-@@ -50,10 +50,10 @@ rte_ipsec_ses_from_crypto(const struct rte_crypto_op *cop)
+@@ -51,10 +51,10 @@ rte_ipsec_ses_from_crypto(const struct rte_crypto_op *cop)
  
  	if (cop->sess_type == RTE_CRYPTO_OP_SECURITY_SESSION) {
  		ss = cop->sym[0].sec_session;

--- a/patches/ring-free.patch
+++ b/patches/ring-free.patch
@@ -8,10 +8,10 @@ From: Aaron Jones <aaron@vexing.codes>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ring/rte_eth_ring.c b/drivers/net/ring/rte_eth_ring.c
-index ab963a03c..17bfaaeb0 100644
+index 733c89825..018b97aa7 100644
 --- a/drivers/net/ring/rte_eth_ring.c
 +++ b/drivers/net/ring/rte_eth_ring.c
-@@ -685,7 +685,7 @@ rte_pmd_ring_remove(struct rte_vdev_device *dev)
+@@ -681,7 +681,7 @@ rte_pmd_ring_remove(struct rte_vdev_device *dev)
  		 * it is only necessary to delete the rings in rx_queues because
  		 * they are the same used in tx_queues
  		 */

--- a/patches/series
+++ b/patches/series
@@ -1,4 +1,5 @@
-# This series applies on GIT commit v19.05
+# This series applies on GIT commit v20.08-rc3
 ring-free.patch
 ipsec_group-cast-rte_ipsec_session.patch
 fix-igb-uio-compile.patch
+trace.patch

--- a/patches/trace.patch
+++ b/patches/trace.patch
@@ -1,0 +1,29 @@
+Fixes a fpermissive conversion error
+
+From: Dennis Afanasev <dennis.afa@gmail.com>
+
+
+---
+ lib/librte_eal/include/rte_trace_point.h |    4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/librte_eal/include/rte_trace_point.h b/lib/librte_eal/include/rte_trace_point.h
+index b03960277..d328a9ff8 100644
+--- a/lib/librte_eal/include/rte_trace_point.h
++++ b/lib/librte_eal/include/rte_trace_point.h
+@@ -298,13 +298,13 @@ RTE_DECLARE_PER_LCORE(void *, trace_mem);
+ static __rte_always_inline void *
+ __rte_trace_mem_get(uint64_t in)
+ {
+-	struct __rte_trace_header *trace = RTE_PER_LCORE(trace_mem);
++	struct __rte_trace_header *trace = (struct __rte_trace_header *) RTE_PER_LCORE(trace_mem);
+ 	const uint16_t sz = in & __RTE_TRACE_FIELD_SIZE_MASK;
+ 
+ 	/* Trace memory is not initialized for this thread */
+ 	if (unlikely(trace == NULL)) {
+ 		__rte_trace_mem_per_thread_alloc();
+-		trace = RTE_PER_LCORE(trace_mem);
++		trace = (struct __rte_trace_header *) RTE_PER_LCORE(trace_mem);
+ 		if (unlikely(trace == NULL))
+ 			return NULL;
+ 	}


### PR DESCRIPTION
Updates our DPDK version to 20.08-rc3. We encounter an fpermissive error when linking DPDK with our NFApp code. This includes a patch to fix that build error. 